### PR TITLE
fix: 회원가입 로고 선택 시 새로고침 오류

### DIFF
--- a/templates/join.html
+++ b/templates/join.html
@@ -1,6 +1,6 @@
 <header class="flex justify-center p-[70px]">
   <h1>
-    <a href="/" aria-label="호두 오픈마켓 홈페이지로 이동">
+    <a href="#" aria-label="호두 오픈마켓 홈페이지로 이동">
       <img
         class="w-[238px]"
         src="../images/Logo-hodu.svg"


### PR DESCRIPTION
회원가입 로고 선택 시 새로고침 오류 해결

- a태그의 href 속성 값을 '/'가 아닌 '#'로 수정