### PR TITLE
fix: 회원가입 비밀번호 체크 이미지 위치 수정

### DIFF
--- a/templates/join.html
+++ b/templates/join.html
@@ -95,7 +95,7 @@
                     min="8"
                     pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^a-zA-Z0-9]).{8,}$"
                     required
-                    class="border-gray-border focus:outline-main w-full rounded-[5px] border p-4"
+                    class="border-gray-border focus:outline-main w-full rounded-[5px] border p-4 pr-15"
                     aria-describedby="passwordMessage"
                   />
                 </div>
@@ -122,7 +122,7 @@
                     pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^a-zA-Z0-9]).{8,}$"
                     required
                     aria-describedby="pwConfirmMessage"
-                    class="border-gray-border focus:outline-main w-full rounded-[5px] border p-4"
+                    class="border-gray-border focus:outline-main w-full rounded-[5px] border p-4 pr-15"
                   />
                 </div>
                 <p


### PR DESCRIPTION
회원가입 비밀번호 체크 이미지 위치 수정

- output.css에서 오류가 있던 것으로 보임
- 확인하는 김에 이미지 쪽 여백 추가