### PR TITLE
fix: 회원가입 아이디 확인 이벤트 오류

### DIFF
--- a/scripts/join.js
+++ b/scripts/join.js
@@ -165,7 +165,7 @@ document.addEventListener("keyup", () => {
 // 전체 확인
 function eventSetting() {
   //1. id 확인
-  DOMElementArray.userId.addEventListener("keyup", (e) => {
+  DOMElementArray.userId.addEventListener("keydown", (e) => {
     if (e.key === "Tab") return;
 
     resetError(DOMElementArray.userId, DOMElementArray.userIdMessage, () => {


### PR DESCRIPTION
회원가입 아이디 확인 이벤트 오류

- userId input에 걸린 keyup 이벤트 -> keydown
  keyup 이벤트 사용 시 중복확인 버튼에서 엔터를 누른 경우 userId input에서 keyup이 되어서 메세지를 제대로 출력하지 못함